### PR TITLE
Fix go.mod and main.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/PryosCode/center
+module github.com/sho7a/center
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/PryosCode/center/cmd"
+	"github.com/sho7a/center/cmd"
 )
 
 func main() {


### PR DESCRIPTION
This just fixes the errors `go` prints when `go install github.com/sho7a/center` is run.